### PR TITLE
fix: ensure Redis healthcheck uses configured port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
     container_name: lago-redis
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-p", "${REDIS_PORT:-6379}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Description
Update the Redis healthcheck to explicitly use the configured port, ensuring it works correctly when users customize their Redis port.

## Problem
The Redis healthcheck fails when using a custom Redis port because the healthcheck command (`redis-cli ping`) does not explicitly specify which port to use. This causes the healthcheck to attempt to connect to the default Redis port (6379) even when Redis is configured to run on a different port.

## Solution
Update the Redis healthcheck to explicitly use the configured port:
```yaml
test: ["CMD", "redis-cli", "-p", "${REDIS_PORT:-6379}", "ping"]